### PR TITLE
Homework4

### DIFF
--- a/k8s/helm-chart/Chart.yaml
+++ b/k8s/helm-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+name: fastapi-chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "3.2.2"

--- a/k8s/helm-chart/templates/online-inference-deployment-rolling-update.yaml
+++ b/k8s/helm-chart/templates/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  replicas: {{ .Values.deployment.replica_count }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.deployment.rollingUpdate_config.maxSurge }}
+      maxUnavailable: {{ .Values.deployment.rollingUpdate_config.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app.name }}
+  template:
+    metadata:
+      name: fastapi-ml
+      labels:
+        app: fastapi-ml
+    spec:
+      containers:
+        - image: {{ .Values.container.image }}
+          name: fastapi-ml
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 1

--- a/k8s/helm-chart/templates/service.yaml
+++ b/k8s/helm-chart/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-service
+spec:
+  selector:
+    app: {{ .Values.app.name }}
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/k8s/helm-chart/values.yaml
+++ b/k8s/helm-chart/values.yaml
@@ -1,0 +1,14 @@
+
+
+app:
+  name: fastapi-ml
+
+container:
+  image: iqgroper/ml_prod_hw:latest
+
+deployment:
+  replica_count: 2
+  
+  rollingUpdate_config:
+      maxSurge: 2
+      maxUnavailable: 1

--- a/k8s/online-inference-deployment-blue-green.yaml
+++ b/k8s/online-inference-deployment-blue-green.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: fastapi-ml
+  template:
+    metadata:
+      name: fastapi-ml
+      labels:
+        app: fastapi-ml
+    spec:
+      containers:
+        - image: iqgroper/ml_prod_hw:latest
+          name: fastapi-ml
+          ports:
+            - containerPort: 8000

--- a/k8s/online-inference-deployment-blue-green.yaml
+++ b/k8s/online-inference-deployment-blue-green.yaml
@@ -25,3 +25,9 @@ spec:
           name: fastapi-ml
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 1

--- a/k8s/online-inference-deployment-rolling-update.yaml
+++ b/k8s/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  replicas: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: fastapi-ml
+  template:
+    metadata:
+      name: fastapi-ml
+      labels:
+        app: fastapi-ml
+    spec:
+      containers:
+        - image: iqgroper/ml_prod_hw:latest
+          name: fastapi-ml
+          ports:
+            - containerPort: 8000

--- a/k8s/online-inference-deployment-rolling-update.yaml
+++ b/k8s/online-inference-deployment-rolling-update.yaml
@@ -25,3 +25,9 @@ spec:
           name: fastapi-ml
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 1

--- a/k8s/online-inference-pod-resources.yaml
+++ b/k8s/online-inference-pod-resources.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  containers:
+    - image: iqgroper/ml_prod_hw:latest
+      name: fastapi-ml
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "50m"
+        limits:
+          memory: "1Gi"
+          cpu: "500m"
+      readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 1

--- a/k8s/online-inference-pod.yaml
+++ b/k8s/online-inference-pod.yaml
@@ -14,5 +14,5 @@ spec:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 15
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 1

--- a/k8s/online-inference-pod.yaml
+++ b/k8s/online-inference-pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  containers:
+    - image: iqgroper/ml_prod_hw:latest
+      name: fastapi-ml
+      ports:
+        - containerPort: 8000
+      readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 3

--- a/k8s/online-inference-pod.yaml
+++ b/k8s/online-inference-pod.yaml
@@ -12,7 +12,7 @@ spec:
         - containerPort: 8000
       readinessProbe:
             httpGet:
-              path: /healthz
+              path: /health
               port: 8000
             initialDelaySeconds: 15
             periodSeconds: 3

--- a/k8s/online-inference-replicaset.yaml
+++ b/k8s/online-inference-replicaset.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: fastapi-ml
+  template:
+    metadata:
+      name: fastapi-ml
+      labels:
+        app: fastapi-ml
+    spec:
+      containers:
+        - image: iqgroper/ml_prod_hw:latest
+          name: fastapi-ml
+          ports:
+            - containerPort: 8000

--- a/k8s/online-inference-replicaset.yaml
+++ b/k8s/online-inference-replicaset.yaml
@@ -20,3 +20,9 @@ spec:
           name: fastapi-ml
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 1


### PR DESCRIPTION
1. Kubernetes развернул с помощью VK Cloud Solutions
Критерий полностью выполнен - 5 баллов
![hw4-1](https://user-images.githubusercontent.com/71259430/175824659-84c89380-42e6-48fe-b2d7-d1a2226cde4e.png)
![hw4-2](https://user-images.githubusercontent.com/71259430/175824660-71f81767-27df-4ec0-9ed4-dac7e1311ffd.png)

2. Докер образ спулился, модель скачалась с ГуглДиска; пробросил порт: можно посмотреть, что на запрос к /heath возвращается True (status code 200)
Критерий полностью выполнен - 4 балла
![hw4-4](https://user-images.githubusercontent.com/71259430/175824680-76e224cb-6bd6-4be3-9704-022ba56af1bb.png)
![hw4-3](https://user-images.githubusercontent.com/71259430/175824681-5a868f05-c978-45ec-86bf-85e746b6df90.png)

3. Мы указываем реквесты, чтобы шедулер мог эффективно распределять поды по нодам, а лимиты для kubelet, чтобы он вовремя убил под, если тот использует слишком много ресурсов.
Критерий полностью выполнен - 2 балла
4. Добавлена Readiness проба - 0.001 ьалла
5. Критерий полностью выполнен - 3 балла
	a) останутся два старых пода, то есть оба будут использовать старый докер образ
	б) старые будут работать со старым образом, новые - с новым.
6. Критерий полностью выполнен - 3 балла
	а) всего запущено 2 пода, потом запускаются новые 2 и когда эти два будут полностью функциональны, удаляются старые два(и вот до удаления как раз есть момент времени, когда на кластере существуют как все старые поды, так и все новые)
	б) всего запущено 5 подов, создаются два новых и один удаляется и так все по очереди, пока не останется пять новых

7. Оформлен Helm Chart, через который можно поднять Service и Deployment
Критерий выполнен не полностью, нет ConfigMap - 3 балла
8.  __-__

Всего: 20 баллов